### PR TITLE
add mp3 to Format / AAC 対応が無くなって MP3 が対応された

### DIFF
--- a/VoiceTextWebAPI.Client/Format.cs
+++ b/VoiceTextWebAPI.Client/Format.cs
@@ -10,6 +10,6 @@ namespace VoiceTextWebAPI.Client
     {
         WAV,
         OGG,
-        AAC
+        MP3
     }
 }


### PR DESCRIPTION
MP3が追加されていたので。一行だけなのですがプルリクします。
フォーマットを指定しているところが `{"format", this.Format.ToString().ToLower()},`だったので、この1行の変更だけで大丈夫だと思ったのですが、もし違かったらすみません