### PR TITLE
update EmotionLevel to 4 levels

### DIFF
--- a/VoiceTextWebAPI.Client/EmotionLevel.cs
+++ b/VoiceTextWebAPI.Client/EmotionLevel.cs
@@ -7,8 +7,9 @@ namespace VoiceTextWebAPI.Client
 {
     public enum EmotionLevel
     {
-        Default = 0,
         Low = 1,
-        High = 2
+        Default = 2,
+        MediumHigh = 3,
+        High = 4
     }
 }


### PR DESCRIPTION
`emotion_level` の段階を4段階にしました。
`Default` の 0 を無指定の意味で残して、1 から 4 を設定するか悩みましたが、
[公式API](https://cloud.voicetext.jp/webapi/docs/api) の初期値に合わせて `Default` を 2 にしています。
